### PR TITLE
Update index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,7 +11,7 @@
             src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js">
     </script>
 
-    <script src="https://polyfill.io/v3/polyfill.min.js?features=default"></script>
+    <script src="https://cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js?version=4.8.0"></script>
 
 </head>
 <body>


### PR DESCRIPTION
I changed Polyfill.io  to  cdnjs.cloudflare.com/polyfill due to a domain attack. It should be able to work by just replacing according to the web but we will have to test to find out.

Links shared with me by Dash:

- [Polyfill Domain Attack](https://blog.redsift.com/news/understanding-the-polyfill-io-domain-attack/)
- [Cloudflare Solution Post](https://blog.cloudflare.com/polyfill-io-now-available-on-cdnjs-reduce-your-supply-chain-risk) 
 > Usage and deployment is intended to be identical to the original polyfill.io site. As a developer, you should be able to simply “replace” the old link with the new cdnjs-hosted link without observing any side effects, besides a possible improvement in performance and reliability. - Cloudflare Post